### PR TITLE
Add OpenAPI specification for Magazine Chat API

### DIFF
--- a/docs/API.yml
+++ b/docs/API.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: Magazine Chat API
+  version: 1.0.0
+paths:
+  /:
+    get:
+      summary: Returns a greeting
+      responses:
+        '200':
+          description: A simple greeting message
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Hello, World!


### PR DESCRIPTION
Introduce OpenAPI 3.0 specification for the Magazine Chat API, detailing the available endpoints and expected responses. Document the root endpoint (`/`) with a GET method that returns a simple greeting message. Fixes #6